### PR TITLE
Fix distribution comparison

### DIFF
--- a/mcerp/__init__.py
+++ b/mcerp/__init__.py
@@ -362,7 +362,7 @@ class UncertainFunction(object):
         # less than val
         if isinstance(val, UncertainFunction):
             tstat, pval = ss.ttest_rel(self._mcpts, val._mcpts)
-            sgn = tstat/abs(tstat)
+            sgn = np.sign(tstat)
             if pval>0.05:  # Since, statistically, we can't really tell
                 return False
             else:
@@ -384,7 +384,7 @@ class UncertainFunction(object):
         # greater than val
         if isinstance(val, UncertainFunction):
             tstat, pval = ss.ttest_rel(self._mcpts, val._mcpts)
-            sgn = tstat/abs(tstat)
+            sgn = np.sign(tstat)
             if pval>0.05:  # Since, statistically, we can't really tell
                 return False
             else:


### PR DESCRIPTION
When comparing Delta functions, scipy.stats.ttest_rel() might return
infinity as t-statistic.  When this happens, comparison fails.

Fix this behaviour by using numpy sign() function.  Scipy.stats still
issues a RuntimeWarning, but apparently it does not affect t-testing
anymore.