### PR TITLE
Fix TypeError and allow keyword overrides when plotting histogram

### DIFF
--- a/mcerp/__init__.py
+++ b/mcerp/__init__.py
@@ -257,8 +257,11 @@ class UncertainFunction(object):
         xp = np.linspace(low,high,100)
 
         if hist:
-            h = plt.hist(vals, bins=np.round(np.sqrt(len(vals))), 
-                     histtype='stepfilled', normed=True, **kwargs)
+            if 'bins' not in kwargs:
+                kwargs['bins'] = int(np.round(np.sqrt(len(vals))))
+            if 'histtype' not in kwargs:
+                kwargs['histtype'] = 'stepfilled'
+            h = plt.hist(vals, normed=True, **kwargs)
             plt.ylim(0, 1.1*h[0].max())
         else:
             plt.plot(xp, p.evaluate(xp), **kwargs)


### PR DESCRIPTION
When using `var.plot(hist=True)` I see a TypeError with Python 3 (stack trace below). This PR also allows the `bins` and `histtype` arguments to be overridden by the user.

```python
/python/lib/python3.6/site-packages/matplotlib/axes/_axes.py in hist(***failed resolving arguments***)
   6528             # this will automatically overwrite bins,
   6529             # so that each histogram uses the same bins
-> 6530             m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)
   6531             m = m.astype(float)  # causes problems later if it's an int
   6532             if mlast is None:

/python/lib/python3.6/site-packages/numpy/lib/histograms.py in histogram(a, bins, range, normed, weights, density)
    700     a, weights = _ravel_and_check_weights(a, weights)
    701
--> 702     bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
    703
    704     # Histogram is an integer or a float array depending on the weights.

/python/lib/python3.6/site-packages/numpy/lib/histograms.py in _get_bin_edges(a, bins, range, weights)
    349         except TypeError:
    350             raise TypeError(
--> 351                 '`bins` must be an integer, a string, or an array')
    352         if n_equal_bins < 1:
    353             raise ValueError('`bins` must be positive, when an integer')

TypeError: `bins` must be an integer, a string, or an array
```