### PR TITLE
Use setuptools_scm for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 build
 MANIFEST
 .idea
+.eggs

--- a/mcerp/__init__.py
+++ b/mcerp/__init__.py
@@ -6,12 +6,16 @@ mcerp: Real-time latin-hypercube-sampling-based Monte Carlo Error Propagation
 Author: Abraham Lee
 Copyright: 2013 - 2014
 """
+from pkg_resources import get_distribution, DistributionNotFound
 import numpy as np
 import scipy.stats as ss
 from .lhd import lhd
 
-__version_info__ = (0, 11)
-__version__ = ".".join(map(str, __version_info__))
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass
 
 __author__ = "Abraham Lee"
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 from setuptools import setup
-import mcerp
 
 
 def read(fname):
@@ -11,7 +10,6 @@ readme = "README.rst"
 
 setup(
     name="mcerp",
-    version=mcerp.__version__,
     author="Abraham Lee",
     description="Real-time latin-hypercube-sampling-based Monte Carlo Error Propagation",
     author_email="tisimst@gmail.com",
@@ -20,6 +18,8 @@ setup(
     long_description=read(readme),
     package_data={"": [readme]},
     packages=["mcerp"],
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     install_requires=["numpy", "scipy", "matplotlib"],
     keywords=[
         "monte carlo",


### PR DESCRIPTION
This PR changes versioning to use https://github.com/pypa/setuptools_scm .

It uses git tags to automatically generate correct version info both for tagged releases and development versions in between, without the maintainer having to edit version numbers manually, making releases quick to do and harder to screw up.

@tisimst - Are you OK with this or do you prefer a different solution?

There are alternatives possible: https://packaging.python.org/guides/single-sourcing-package-version/ . E.g. we could keep the version number manually maintained in `mcerp/__init__.py`, and extract it with a regex in `setup.py`, that's also what many projects do to avoid importing the package, or duplicating the version number in two places.

@henryiii - this will address issue #6 that you filed a while ago.