### PR TITLE
Plotting: change histogram keyword "normed" to "density"

### DIFF
--- a/mcerp/__init__.py
+++ b/mcerp/__init__.py
@@ -268,7 +268,7 @@ class UncertainFunction(object):
                 vals,
                 bins=int(np.sqrt(len(vals)) + 0.5),
                 histtype="stepfilled",
-                normed=True,
+                density=True,
                 **kwargs
             )
             plt.ylim(0, 1.1 * h[0].max())
@@ -676,7 +676,7 @@ class UncertainVariable(UncertainFunction):
                 vals,
                 bins=int(np.sqrt(len(vals)) + 0.5),
                 histtype="stepfilled",
-                normed=True,
+                density=True,
                 **kwargs
             )
             plt.ylim(0, 1.1 * h[0].max())


### PR DESCRIPTION
Fixed the histogram plotting call to be compatible with newer versions of Matplotlib (>=2.1.0).
Reference: https://matplotlib.org/3.3.2/users/prev_whats_new/whats_new_2.1.0.html?highlight=hist#density-kwarg-to-hist 