### PR TITLE
Plotting: added class method "get_subplotspec()" for correlation subplots

### DIFF
--- a/mcerp/correlate.py
+++ b/mcerp/correlate.py
@@ -131,18 +131,18 @@ def plotcorr(X, plotargs=None, full=True, labels=None):
 
         # Set up ticks only on one side for the "edge" subplots...
         if full:
-            if ax.is_first_col():
+            if ax.get_subplotspec().is_first_col():
                 ax.yaxis.set_ticks_position("left")
-            if ax.is_last_col():
+            if ax.get_subplotspec().is_last_col():
                 ax.yaxis.set_ticks_position("right")
-            if ax.is_first_row():
+            if ax.get_subplotspec().is_first_row():
                 ax.xaxis.set_ticks_position("top")
-            if ax.is_last_row():
+            if ax.get_subplotspec().is_last_row():
                 ax.xaxis.set_ticks_position("bottom")
         else:
-            if ax.is_first_row():
+            if ax.get_subplotspec().is_first_row():
                 ax.xaxis.set_ticks_position("top")
-            if ax.is_last_col():
+            if ax.get_subplotspec().is_last_col():
                 ax.yaxis.set_ticks_position("right")
 
     # Label the diagonal subplots...


### PR DESCRIPTION
Integration of a Matplotlib API change to plot correlation matrix for versions >=3.6.0: "Subplot.is_first_row(); use ax.get_subplotspec().is_first_row instead. ..."
https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.6.0.html#classes-methods-and-attributes