### PR TITLE
Fix LogNormal to use scale=mu instead of loc=mu

### DIFF
--- a/mcerp/core.py
+++ b/mcerp/core.py
@@ -1129,7 +1129,7 @@ def _log_normal(
         The sampled uncertain value.
     """
     _validate(sigma > 0, 'Log-Normal "sigma" must be positive')
-    return uv(ss.lognorm(sigma, loc=mu), tag=tag)
+    return uv(ss.lognorm(sigma, scale=mu), tag=tag)
 
 
 def _normal(


### PR DESCRIPTION
In scipy's lognorm, the `scale` parameter maps to exp(mu) of the underlying normal distribution, while `loc` shifts the whole distribution. Using `loc` produced an incorrect distribution shape.

Closes #28