### PR TITLE
Exclude tests, docs and tooling from SonarQube Cloud analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,16 @@
+# SonarQube Cloud analysis scope.
+#
+# Analyse application source only. Tests, build tooling, documentation
+# and CI workflow definitions are never shipped in the published
+# package, so findings there fail the quality gate without describing
+# any risk to users of this project.
+#
+# Every path listed below was verified to exist in this repository;
+# directories this project does not have are deliberately omitted
+# rather than carried over from a sibling repo.
+#
+# This also covers githubactions:S8541, which asks for uv's
+# `--no-build`. That flag cannot be used by a project built from
+# source: uv refuses with "can't be installed because it is marked as
+# `--no-build` but has no binary distribution".
+sonar.exclusions=.github/**,tests/**,docs/**


### PR DESCRIPTION
SonarQube Cloud was analysing paths that are never shipped in the published
package. Findings in tests, build tooling, documentation and CI definitions
counted against the quality gate without describing any risk to users.

```
sonar.exclusions=.github/**,tests/**,docs/**
```

**Every path above was verified to exist in this repository.** Directories this
project does not have are omitted rather than copied from a sibling repo, so
the config stays accurate and readable.

This also covers `githubactions:S8541`, which asks for uv's `--no-build` — a
flag no source-built project can use, since uv refuses with `can't be installed
because it is marked as --no-build but has no binary distribution`.

Note the filename: this project runs **Automatic Analysis**, which reads
`.sonarcloud.properties`. `sonar-project.properties` is only read by CI-based
analysis and is silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)