### PR TITLE
chore(docs): use absolute asset URLs and project icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![MCERP](docs/assets/mcerp-banner.png)
+![MCERP](https://raw.githubusercontent.com/eggzec/mcerp/master/docs/assets/mcerp-banner.png)
 
 # MCERP
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-![MCERP](assets/mcerp-banner.png)
+![MCERP](https://raw.githubusercontent.com/eggzec/mcerp/master/docs/assets/mcerp-banner.png)
 
 # MCERP
 
-![MCERP](./_static/logo.png)
+![MCERP](https://raw.githubusercontent.com/eggzec/mcerp/master/docs/assets/mcerp-icon.svg){ width="120" }
 
 **Real-time latin-hypercube-sampling-based Monte Carlo error propagation for
 Python.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ extra:
 
 theme:
   name: material
-  logo: _static/logo.png
-  favicon: _static/favicon.ico
+  logo: assets/mcerp-icon.svg
+  favicon: assets/mcerp-icon.png
   features:
     - content.code.copy
 


### PR DESCRIPTION
Points README and docs image references at `raw.githubusercontent.com` absolute URLs so banners render on GitHub and PyPI instead of breaking on relative paths, and sets the MkDocs/Zensical theme `logo` and `favicon` to the current project icon (replacing stale or missing entries).

Verified: every config still parses and all referenced icon files exist on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)